### PR TITLE
feat: spoiler timestamps; toml config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .venv
 __pycache__
+test.py
+config.toml

--- a/config.toml.example
+++ b/config.toml.example
@@ -9,9 +9,11 @@ group =
 [tautulli]
 api =
 
-[players]
-"+15555555555" = "tautulli_user"
+[plex_players]
+"tautulli_user" = "John Smith"
 
+[signal_players]
+"+15555555555" = "tautulli_user"
 
 [database]
 host =

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,0 +1,19 @@
+[survivor]
+season =
+
+[signal]
+api =
+number
+group =
+
+[tautulli]
+api =
+
+[players]
+"+15555555555" = "tautulli_user"
+
+
+[database]
+host =
+db =
+user =

--- a/config.toml.example
+++ b/config.toml.example
@@ -13,7 +13,7 @@ api =
 "tautulli_user" = "John Smith"
 
 [signal_players]
-"+15555555555" = "tautulli_user"
+"signal name" = "tautulli_user"
 
 [database]
 host =

--- a/main.py
+++ b/main.py
@@ -39,20 +39,8 @@ def activity(activity: Activity):
     season = activity.season.zfill(2)
     episode = activity.episode.zfill(2)
 
-    """
-    Update username so it shows personalized names
-    """
-    watcher = activity.username
-    if watcher:
-        if watcher == "riley_snyder":
-            watcher = "Riley and Nicole"
-        elif watcher == "hmfis":
-            watcher = "Hannah and Sweepy"
-        elif watcher == "mose162":
-            watcher = "Hunter"
-        elif watcher == "barry.sa":
-            watcher = "Barry and Marcin"
-        return watcher
+    # Update username so it shows personalized names
+    watcher = config["plex_users"][activity.username]
 
     if season != config["survivor"]["season"]:
         logging.info(f"off season viewing: {watcher}")

--- a/main.py
+++ b/main.py
@@ -70,7 +70,7 @@ def activity(activity: Activity):
     if position == 4:
         score_message = "Current Scores:"
         for username, score in get_stats(season):
-            score_message += f"\n{watcher}: {score}"
+            score_message += f"\n{config['plex_users'][username]}: {score}"
         send(
             config["signal"]["api"],
             config["signal"]["number"],

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.90.1
 requests
 uvicorn[standard]
 psycopg[binary,pool]
+tomli

--- a/signalm.py
+++ b/signalm.py
@@ -1,0 +1,19 @@
+import logging
+
+from requests import post
+
+
+def send(api: str, number: str, recipient: str, message: str) -> str:
+    resp = post(
+        f"http://{api}/v2/send",
+        json={
+            "message": message,
+            "number": number,
+            "recipients": [recipient],
+        },
+    )
+
+    if resp.status_code >= 400:
+        logging.error(resp.text)
+    else:
+        logging.info(resp.text)

--- a/spoilers.py
+++ b/spoilers.py
@@ -31,7 +31,7 @@ async def receive():
         raise e
 
 
-async def wait_for_spoilers(groupId: str):
+async def wait_for_spoilers(groupId: str, season: str):
     # loop through all new messages
 
     logging.info("waiting for spoilers...")
@@ -79,7 +79,7 @@ async def wait_for_spoilers(groupId: str):
             for x in resp.json()["response"]["data"]["sessions"]
             if (
                 (x.get("grandparent_title") == "Survivor")
-                and (x.get("parent_title").split(" ")[-1] == "47")
+                and (x.get("parent_title").split(" ")[-1] == season)
                 and (config["signal_players"].get(signal_user) == x.get("username"))
             )
         ]:
@@ -113,4 +113,6 @@ if __name__ == "__main__":
 
     event_loop = get_event_loop()
 
-    event_loop.run_until_complete(wait_for_spoilers(groupId))
+    event_loop.run_until_complete(
+        wait_for_spoilers(groupId, config["survivor"]["season"])
+    )

--- a/spoilers.py
+++ b/spoilers.py
@@ -63,7 +63,7 @@ async def wait_for_spoilers(groupId: str, season: str):
             logging.debug("not a spoiler")
             continue
 
-        signal_user = message["envelope"]["source"]
+        signal_user = message["envelope"]["sourceName"]
 
         resp = get(
             f"http://{config['tautulli']['api']}/api/v2?apikey={getenv('TAUTULLI_KEY')}&cmd=get_activity"

--- a/spoilers.py
+++ b/spoilers.py
@@ -1,0 +1,102 @@
+from websockets import connect
+from asyncio import get_event_loop
+from json import loads
+from os import getenv
+import logging
+
+from requests import get
+from tomli import load
+
+from signalm import send
+
+
+logging.basicConfig(level=getenv("LOGLEVEL", "INFO").upper())
+
+with open("config.toml", mode="rb") as fp:
+    config = load(fp)
+
+
+async def receive():
+    # receive messages from signal via json rpc
+
+    try:
+        async with connect(
+            f"ws://{config['signal']['api']}/v1/receive/{config['signal']['number']}",
+            ping_interval=None,
+        ) as websocket:
+            async for raw_message in websocket:
+                yield raw_message
+    except Exception as e:
+        raise e
+
+
+async def wait_for_spoilers():
+    # loop through all new messages
+
+    logging.info("waiting for spoilers...")
+
+    async for raw_message in receive():
+
+        # load in message
+        try:
+            message = loads(raw_message)
+        except Exception as e:
+            print("unable to load message: ", e)
+            continue
+
+        # ignore anything other than messages
+        if "dataMessage" not in message["envelope"]:
+            continue
+
+        # skip non spoilers
+        if not [
+            x
+            for x in message["envelope"]["dataMessage"].get("textStyles", [])
+            if x.get("style") == "SPOILER"
+        ]:
+            continue
+
+        signal_user = message["envelope"]["source"]
+
+        resp = get(
+            f"http://{config['tautulli']['api']}/api/v2?apikey={getenv('TAUTULLI_KEY')}&cmd=get_activity"
+        )
+
+        # get current streams of survivor
+        # in the current season
+        # for the current player
+        for stream in [
+            x
+            for x in resp.json()["response"]["data"]["sessions"]
+            if (
+                (x.get("grandparent_title") == "Survivor")
+                and (x.get("parent_title").split(" ")[-1] == "47")
+                and (config["players"].get(signal_user) == x.get("username"))
+            )
+        ]:
+            # calculate position in the episode
+            min = (
+                float(stream.get("progress_percent"))
+                * float(stream.get("stream_duration"))
+                / 6000000
+            )
+            if min > 60:
+                position = f"1h{int(min - 60)}m"
+            else:
+                position = f"{int(min)}m"
+
+            print(
+                send(
+                    config["signal"]["api"],
+                    config["signal"]["number"],
+                    config["signal"]["group"],
+                    position,
+                )
+            )
+
+
+if __name__ == "__main__":
+
+    event_loop = get_event_loop()
+
+    event_loop.run_until_complete(wait_for_spoilers())

--- a/spoilers.py
+++ b/spoilers.py
@@ -69,6 +69,8 @@ async def wait_for_spoilers(groupId: str):
             f"http://{config['tautulli']['api']}/api/v2?apikey={getenv('TAUTULLI_KEY')}&cmd=get_activity"
         )
 
+        resp.raise_for_status()
+
         # get current streams of survivor
         # in the current season
         # for the current player
@@ -107,7 +109,7 @@ async def wait_for_spoilers(groupId: str):
 if __name__ == "__main__":
 
     # decode the group id
-    groupId = b64decode(config["signal"]["group"].split(".")[-1])
+    groupId = b64decode(config["signal"]["group"].split(".")[-1]).decode("utf-8")
 
     event_loop = get_event_loop()
 

--- a/spoilers.py
+++ b/spoilers.py
@@ -71,7 +71,7 @@ async def wait_for_spoilers():
             if (
                 (x.get("grandparent_title") == "Survivor")
                 and (x.get("parent_title").split(" ")[-1] == "47")
-                and (config["players"].get(signal_user) == x.get("username"))
+                and (config["signal_players"].get(signal_user) == x.get("username"))
             )
         ]:
             # calculate position in the episode

--- a/spoilers.py
+++ b/spoilers.py
@@ -46,6 +46,7 @@ async def wait_for_spoilers():
 
         # ignore anything other than messages
         if "dataMessage" not in message["envelope"]:
+            logging.debug("not a message")
             continue
 
         # skip non spoilers
@@ -54,6 +55,7 @@ async def wait_for_spoilers():
             for x in message["envelope"]["dataMessage"].get("textStyles", [])
             if x.get("style") == "SPOILER"
         ]:
+            logging.debug("not a spoiler")
             continue
 
         signal_user = message["envelope"]["source"]
@@ -93,6 +95,8 @@ async def wait_for_spoilers():
                     position,
                 )
             )
+
+            logging.info(f"tagged spoiler for {signal_user} at {position}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
when someone sends a spoiler in the gc, send the timestamp of where they are in the episode.

this allows others to look at comments as they watch along.

--

also, switch to toml for most config. leaving secrets and log level in the env.